### PR TITLE
Use gh CLI instead of actions/create-release@v1 action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,14 +20,9 @@ jobs:
           RELEASE_VERSION: ${{ steps.release_version.outputs.RELEASE_VERSION }}
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        run: gh release create ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
       - uses: docker/login-action@v1
         with:
           registry: registry.replicated.com


### PR DESCRIPTION
The `actions/create-release@v1` action is failing with 

```
Run actions/create-release@v1
  with:
    tag_name: refs/tags/v1.0.17
    release_name: Release refs/tags/v1.0.17
    draft: false
    prerelease: false
  env:
    GITHUB_TOKEN: ***
Error: Resource not accessible by integration
```